### PR TITLE
Feature/dbms versions to match license code

### DIFF
--- a/UDAEnterpriseOffers-Licenses-Prices.ttl
+++ b/UDAEnterpriseOffers-Licenses-Prices.ttl
@@ -90,9 +90,14 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:serverWorkstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:model "http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this" ;
+	schema:model <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-department-2019-01#this> ;
+	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7JDBCBridge#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7ODBCBridge#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7SQLServer#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Oracle#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Sybase#this> ;
 	license:hasMaximumUsers "unlimited" ;
 	schema:name "Department License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System" ;
 	skos:prefLabel "Department License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System" ;
@@ -257,7 +262,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-department-2019-01#this> ;
 	schema:name "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> schema:model "http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this" ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> schema:model <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-department-2019-01#this> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-department-2019-01#this> .
@@ -410,7 +415,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2019-01#this> ;
 	schema:name "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, for deployment on any supported Workstation- or Server-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> schema:model "http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this" ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> schema:model <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2019-01#this> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2019-01#this> .
@@ -563,7 +568,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2019-01#this> ;
 	schema:name "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> schema:model "http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this" ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> schema:model <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2019-01#this> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2019-01#this> .
@@ -670,7 +675,7 @@
 	schema:name "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01%23this"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01#this> schema:mainEntityOfPage <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01%23this> ;
-	schema:itemOffered <http://data.openlinksw.com/oplweb/offer#http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2FlicenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01%23this+> .
+	schema:itemOffered <http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDAEnterpriseSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -712,15 +717,20 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01#this> ;
 	schema:name "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/offer#http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2FlicenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01%23this+> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:workstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:model "http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this" ;
+	schema:model <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01#this> ;
+	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7JDBCBridge#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7ODBCBridge#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7SQLServer#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Oracle#this> ,
+		<http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Sybase#this> ;
 	license:hasMaximumUsers "unlimited" ;
 	schema:name "Personal License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
 	skos:prefLabel "Personal License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
@@ -894,7 +904,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2019-01#this> ;
 	schema:name "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> schema:model "http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this" ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> schema:model <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2019-01#this> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2019-01#this> .
@@ -969,7 +979,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2019-01#this> ;
 	schema:name "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> schema:model "http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this" ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> schema:model <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2019-01#this> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2019-01#this> .

--- a/UDASTLiteOffers-Licenses-Prices.ttl
+++ b/UDASTLiteOffers-Licenses-Prices.ttl
@@ -353,7 +353,7 @@
 	license:hasLicenseFileName "inf9_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Informix ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Informix11 .
+	oplsof:hasDatabaseEngine oplsof:Informix9 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-inf9-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -563,7 +563,7 @@
 	license:hasLicenseFileName "inf9_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Informix ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Informix11 .
+	oplsof:hasDatabaseEngine oplsof:Informix9 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-inf9-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -633,7 +633,7 @@
 	license:hasLicenseFileName "inf9_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Informix ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Informix11 .
+	oplsof:hasDatabaseEngine oplsof:Informix9 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-inf9-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -1135,7 +1135,7 @@
 	license:hasLicenseFileName "mys3_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:MySQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:MySQL5 .
+	oplsof:hasDatabaseEngine oplsof:MySQL3 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-mys3-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -1205,7 +1205,7 @@
 	license:hasLicenseFileName "mys4_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:MySQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:MySQL5 .
+	oplsof:hasDatabaseEngine oplsof:MySQL4 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-mys4-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -1345,7 +1345,7 @@
 	license:hasLicenseFileName "mys3_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:MySQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:MySQL5 .
+	oplsof:hasDatabaseEngine oplsof:MySQL3 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-mys3-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -1415,7 +1415,7 @@
 	license:hasLicenseFileName "mys3_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:MySQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:MySQL5 .
+	oplsof:hasDatabaseEngine oplsof:MySQL3 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-mys3-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -1485,7 +1485,7 @@
 	license:hasLicenseFileName "mys4_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:MySQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:MySQL5 .
+	oplsof:hasDatabaseEngine oplsof:MySQL4 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-mys4-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -1555,7 +1555,7 @@
 	license:hasLicenseFileName "mys4_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:MySQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:MySQL5 .
+	oplsof:hasDatabaseEngine oplsof:MySQL4 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-mys4-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -2188,7 +2188,7 @@
 	license:hasLicenseFileName "ora10_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Oracle12 .
+	oplsof:hasDatabaseEngine oplsof:Oracle10 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-ora10-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -2258,7 +2258,7 @@
 	license:hasLicenseFileName "ora11_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Oracle12 .
+	oplsof:hasDatabaseEngine oplsof:Oracle11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-ora11-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -2398,7 +2398,7 @@
 	license:hasLicenseFileName "ora10_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Oracle12 .
+	oplsof:hasDatabaseEngine oplsof:Oracle10 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-ora10-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -2468,7 +2468,7 @@
 	license:hasLicenseFileName "ora10_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Oracle12 .
+	oplsof:hasDatabaseEngine oplsof:Oracle10 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-ora10-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -2538,7 +2538,7 @@
 	license:hasLicenseFileName "ora11_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Oracle12 .
+	oplsof:hasDatabaseEngine oplsof:Oracle11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-ora11-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -2608,7 +2608,7 @@
 	license:hasLicenseFileName "ora11_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Oracle12 .
+	oplsof:hasDatabaseEngine oplsof:Oracle11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-ora11-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -3036,7 +3036,7 @@
 	license:hasLicenseFileName "pro10_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Progress ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Progress11 .
+	oplsof:hasDatabaseEngine oplsof:Progress10 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-pro10-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -3176,7 +3176,7 @@
 	license:hasLicenseFileName "pro9_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Progress ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Progress11 .
+	oplsof:hasDatabaseEngine oplsof:Progress9 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-pro9-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -3246,7 +3246,7 @@
 	license:hasLicenseFileName "pro10_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Progress ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Progress11 .
+	oplsof:hasDatabaseEngine oplsof:Progress10 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-pro10-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -3316,7 +3316,7 @@
 	license:hasLicenseFileName "pro10_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Progress ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Progress11 .
+	oplsof:hasDatabaseEngine oplsof:Progress10 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-pro10-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -3526,7 +3526,7 @@
 	license:hasLicenseFileName "pro9_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Progress ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Progress11 .
+	oplsof:hasDatabaseEngine oplsof:Progress9 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-pro9-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -3596,7 +3596,7 @@
 	license:hasLicenseFileName "pro9_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Progress ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:Progress11 .
+	oplsof:hasDatabaseEngine oplsof:Progress9 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-pro9-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;


### PR DESCRIPTION
Fixed the oplsof:hasDatabaseEngine relation of the license descriptions to match the license codes.