### PR TITLE
Develop

### DIFF
--- a/UDAEnterpriseOffers-Licenses-Prices.ttl
+++ b/UDAEnterpriseOffers-Licenses-Prices.ttl
@@ -1947,3 +1947,83 @@
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2019-09#this> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2019-09#this> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> a schema:Offer , offers:UDAEnterpriseOffer , offers:UDAEnterpriseSpecialOffer ;
+	schema:url <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09> ;
+	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09-special-price#this> ;
+	schema:itemOffered <http://data.openlinksw.com/oplweb/license/AnyDataAccesspostgresAnyOSWKSDBAgentLicense8-personal-2019-09#this> ;
+	schema:image <http://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+	skos:prefLabel "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
+	schema:comment "Personal License (5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System" ;
+	schema:category "personal" ;
+	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
+	schema:description "Software License Offer: Personal License (5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, for deployment on any supported Workstation-class Operating System" ;
+	offers:offerNumber "UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	schema:name "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, for deployment on any supported Workstation-class Operating System." ;
+	skos:related <http://data.openlinksw.com/oplweb/product/odbc-postgres-mt#this> ;
+	license:hasBuyService <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this&type=buy&mode=u> ;
+	schema:potentialAction <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this> .
+
+<http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this&type=buy&mode=u> schema:description "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	schema:name "HTML Document Generated via BuyAction for  listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> schema:mainEntityOfPage <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this&type=buy&mode=u> .
+
+<https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this> schema:description "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this"^^<http://www.w3.org/2001/XMLSchema#string> ;
+	schema:name "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> schema:mainEntityOfPage <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09%23this> ;
+	schema:itemOffered <http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2019-09#this> .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDAEnterpriseSpecialUnitPriceSpecification ;
+	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	schema:name "Personal License Special Price Specification to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
+	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09-retail-price#this> ;
+	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesspostgresAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+	oplsof:hasOperatingSystemType oplsof:workstationOS ;
+	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
+	schema:description "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, without expiration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts." ;
+	schema:image <http://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8PostgreSQL#this> ;
+	schema:name "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
+	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-mt#this> ;
+	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> ;
+	skos:prefLabel "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
+	schema:comment "Personal License (5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System" ;
+	license:hasLicenseCode "postgres" ;
+	license:hasLicenseFileName "postgres.lic" ;
+	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
+	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
+	oplsof:hasDatabaseEngine oplsof:PostgresSQL6 ,
+	        oplsof:PostgreSQL7,
+	        oplsof:PostgreSQL8 ,
+	        oplsof:PostgreSQL9 ,
+	        oplsof:PostgreSQL10 ,
+	        oplsof:PostgreSQL11 ;
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
+	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+	schema:name "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System" ;
+	schema:price "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> ;
+	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> ;
+	schema:name "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2019-09#this> schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-mt#this> ;
+	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> .
+
+<http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09#this> .

--- a/UDAEnterpriseOffers-Licenses-Prices.ttl
+++ b/UDAEnterpriseOffers-Licenses-Prices.ttl
@@ -50,7 +50,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -84,7 +84,7 @@
 	schema:name "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> ;
 	schema:publisher <http://www.openlinksw.com/#this> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -148,7 +148,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -230,7 +230,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -305,7 +305,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -383,7 +383,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -458,7 +458,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -536,7 +536,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense7-department-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -611,7 +611,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense7-workgroup-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -685,7 +685,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -717,7 +717,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01#this> ;
 	schema:name "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -781,7 +781,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -813,7 +813,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2019-01#this> ;
 	schema:name "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -872,7 +872,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -947,7 +947,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense7-personal-2019-01#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1026,7 +1026,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1060,7 +1060,7 @@
 	schema:name "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> ;
 	schema:publisher <http://www.openlinksw.com/#this> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSSVRRequestBrokerLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1124,7 +1124,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1202,7 +1202,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1277,7 +1277,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1351,7 +1351,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1426,7 +1426,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1500,7 +1500,7 @@
 	schema:price "7499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense8-department-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1575,7 +1575,7 @@
 	schema:price "3374.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSSVRDBAgentLicense8-workgroup-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1649,7 +1649,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1681,7 +1681,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-09#this> ;
 	schema:name "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1745,7 +1745,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1777,7 +1777,7 @@
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2019-09#this> ;
 	schema:name "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:RequestBrokerLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1836,7 +1836,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1911,7 +1911,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -1986,7 +1986,7 @@
 	schema:price "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
-<http://data.openlinksw.com/oplweb/license/AnyDataAccesspostgresAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:UDAMTLicense ;
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesspostgresAnyOSWKSDBAgentLicense8-personal-2019-09#this> a schema:Product , license:ProductLicense , license:NonExpiringLicense , license:DatabaseAgentLicense, license:UDAMTLicense ;
 	license:hasSessions "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:hasMaximumProcessorCores "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -2010,7 +2010,7 @@
 	        oplsof:PostgreSQL8 ,
 	        oplsof:PostgreSQL9 ,
 	        oplsof:PostgreSQL10 ,
-	        oplsof:PostgreSQL11 ;
+	        oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-postgres-personal-2019-09-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;

--- a/UDAEnterpriseOffers-Licenses-Prices.ttl
+++ b/UDAEnterpriseOffers-Licenses-Prices.ttl
@@ -69,7 +69,7 @@
 	license:hasLicenseFileName "jdbc.lic" ;
 	oplsof:hasDatabaseFamily oplsof:JDBCBridge ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#jdbc" .
+	oplsof:hasDatabaseEngine oplsof:jdbc .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-jdbc-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -167,7 +167,7 @@
 	license:hasLicenseFileName "jdbc.lic" ;
 	oplsof:hasDatabaseFamily oplsof:JDBCBridge ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#jdbc" .
+	oplsof:hasDatabaseEngine oplsof:jdbc .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -249,7 +249,7 @@
 	license:hasLicenseFileName "odbc.lic" ;
 	oplsof:hasDatabaseFamily oplsof:ODBCBridge ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#odbc" .
+	oplsof:hasDatabaseEngine oplsof:odbc .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-odbc-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -324,7 +324,7 @@
 	license:hasLicenseFileName "odbc.lic" ;
 	oplsof:hasDatabaseFamily oplsof:ODBCBridge ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#odbc" .
+	oplsof:hasDatabaseEngine oplsof:odbc .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-odbc-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -402,7 +402,7 @@
 	license:hasLicenseFileName "oracle12.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#Oracle12" .
+	oplsof:hasDatabaseEngine oplsof:Oracle12 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -477,7 +477,7 @@
 	license:hasLicenseFileName "oracle12.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#Oracle12" .
+	oplsof:hasDatabaseEngine oplsof:Oracle12 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-oracle12-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -555,7 +555,7 @@
 	license:hasLicenseFileName "sqlserver.lic" ;
 	oplsof:hasDatabaseFamily oplsof:SQLServer ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#SQLServer2014" .
+	oplsof:hasDatabaseEngine oplsof:SQLServer2014 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -630,7 +630,7 @@
 	license:hasLicenseFileName "sqlserver.lic" ;
 	oplsof:hasDatabaseFamily oplsof:SQLServer ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#SQLServer2014" .
+	oplsof:hasDatabaseEngine oplsof:SQLServer2014 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -704,7 +704,7 @@
 	license:hasLicenseFileName "jdbc.lic" ;
 	oplsof:hasDatabaseFamily oplsof:JDBCBridge ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#jdbc" .
+	oplsof:hasDatabaseEngine oplsof:jdbc .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -800,7 +800,7 @@
 	license:hasLicenseFileName "odbc.lic" ;
 	oplsof:hasDatabaseFamily oplsof:ODBCBridge ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#odbc" .
+	oplsof:hasDatabaseEngine oplsof:odbc .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-odbc-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -891,7 +891,7 @@
 	license:hasLicenseFileName "oracle12.lic" ;
 	oplsof:hasDatabaseFamily oplsof:Oracle ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#Oracle12" .
+	oplsof:hasDatabaseEngine oplsof:Oracle12 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
@@ -966,7 +966,7 @@
 	license:hasLicenseFileName "sqlserver.lic" ;
 	oplsof:hasDatabaseFamily oplsof:SQLServer ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessProtocolAny ;
-	oplsof:hasDatabaseEngine "http://www.openlinksw.com/ontology/software#SQLServer2014" .
+	oplsof:hasDatabaseEngine oplsof:SQLServer2014 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;

--- a/UDASTLiteOffers-Licenses-Prices.ttl
+++ b/UDASTLiteOffers-Licenses-Prices.ttl
@@ -2770,13 +2770,13 @@
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-01-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/UDALTODBCRelease7LicenseWKS-anyos-postgres-personal-2019-01#this> ;
 	schema:image <http://uda.openlinksw.com/images/udast-basicworkstation-license.png> ;
-	skos:prefLabel "Software License: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
-	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	skos:prefLabel "Software License: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
+	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	schema:category "personal" ;
 	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
-	schema:description "Software License Offer: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System." ;
+	schema:description "Software License Offer: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System." ;
 	offers:offerNumber "UDALT-WKS-anyos-odbc-postgres-personal-2019-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
-	schema:name "Software License Offer: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" .
+	schema:name "Software License Offer: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" .
 
 <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> oplpro:hasFormat <http://data.openlinksw.com/oplweb/product_format/st#this> ;
 	oplpro:hasFamily <http://data.openlinksw.com/oplweb/product_family/uda#this> .
@@ -2798,7 +2798,7 @@
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-01-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDALiteSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-03-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software License Special Price Specification: Personal License Special Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software License Special Price Specification: Personal License Special Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-01-retail-price#this> ;
 	schema:price "99.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -2809,31 +2809,35 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:workstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:description "Personal License for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x for installation on one (1) host with up to 16 logical processors, running a Workstation-class Operating System. Allows five (5) concurrent ODBC data access sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
+	schema:description "Personal License for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for installation on one (1) host with up to 16 logical processors, running a Workstation-class Operating System. Allows five (5) concurrent ODBC data access sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
 	schema:image <http://uda.openlinksw.com/images/udast-basicworkstation-license.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease7PostgreSQL#this> ;
-	schema:name "Software License: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software License: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-01#this> ;
-	skos:prefLabel "Software License: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
-	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	skos:prefLabel "Software License: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
+	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	license:hasLicenseCode "pgr7_lt" ;
 	license:hasLicenseFileName "pgr7_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:PostgreSQL9 .
+	oplsof:hasDatabaseEngine oplsof:PostgreSQL7 ,  
+                                 oplsof:PostgreSQL8 ,
+                                 oplsof:PostgreSQL9 ,
+                                 oplsof:PostgreSQL10 ,
+                                 oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-03-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software Software License Retail Price Specification: Personal Software License Retail Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software Software License Retail Price Specification: Personal Software License Retail Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	schema:price "299.98"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-01#this> ;
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-01#this> ;
-	schema:name "Software License Offer: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
+	schema:name "Software License Offer: Personal License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-01#this> .
 
@@ -2844,13 +2848,13 @@
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/UDALTODBCRelease7LicenseWKSSVR-anyos-postgres-department-2019-01#this> ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
-	skos:prefLabel "Software License: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:category "department" ;
 	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
-	schema:description "Software License Offer: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:description "Software License Offer: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:offerNumber "UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
-	schema:name "Software License Offer: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Offer: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	skos:related <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:hasBuyService <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01%23this&type=buy&mode=u> ;
 	schema:potentialAction <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01%23this> .
@@ -2868,7 +2872,7 @@
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDALiteSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-03-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software License Special Price Specification: Department License Special Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Special Price Specification: Department License Special Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01-retail-price#this> ;
 	schema:price "1312.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -2879,31 +2883,35 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:serverWorkstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:description "Department License for Lite Edition (Release 7.x) ODBC Driver for ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows twenty-five (25) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
+	schema:description "Department License for Lite Edition (Release 7.x) ODBC Driver for ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows twenty-five (25) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease7PostgreSQL#this> ;
-	schema:name "Software License: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01#this> ;
-	skos:prefLabel "Software License: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	license:hasLicenseCode "pgr7_lt" ;
 	license:hasLicenseFileName "pgr7_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:PostgreSQL9 .
+	oplsof:hasDatabaseEngine oplsof:PostgreSQL7 ,  
+                                 oplsof:PostgreSQL8 ,
+                                 oplsof:PostgreSQL9 ,
+                                 oplsof:PostgreSQL10 ,
+                                 oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-03-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software Software License Retail Price Specification: Department Software License Retail Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software Software License Retail Price Specification: Department Software License Retail Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:price "3937.24"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01#this> ;
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01#this> ;
-	schema:name "Software License Offer: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
+	schema:name "Software License Offer: Department License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-01#this> .
 
@@ -2914,13 +2922,13 @@
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/UDALTODBCRelease7LicenseWKSSVR-anyos-postgres-workgroup-2019-01#this> ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
-	skos:prefLabel "Software License: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:category "workgroup" ;
 	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
-	schema:description "Software License Offer: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:description "Software License Offer: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:offerNumber "UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
-	schema:name "Software License Offer: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Offer: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	skos:related <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:hasBuyService <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01%23this&type=buy&mode=u> ;
 	schema:potentialAction <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01%23this> .
@@ -2938,7 +2946,7 @@
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDALiteSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-03-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software License Special Price Specification: Workgroup License Special Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Special Price Specification: Workgroup License Special Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01-retail-price#this> ;
 	schema:price "524.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -2949,31 +2957,35 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:serverWorkstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:description "Workgroup License for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows ten (10) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
+	schema:description "Workgroup License for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows ten (10) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease7PostgreSQL#this> ;
-	schema:name "Software License: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01#this> ;
-	skos:prefLabel "Software License: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 7.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	license:hasLicenseCode "pgr7_lt" ;
 	license:hasLicenseFileName "pgr7_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:PostgreSQL9 .
+	oplsof:hasDatabaseEngine oplsof:PostgreSQL7 ,  
+                                 oplsof:PostgreSQL8 ,
+                                 oplsof:PostgreSQL9 ,
+                                 oplsof:PostgreSQL10 ,
+                                 oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-03-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software Software License Retail Price Specification: Workgroup Software License Retail Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software Software License Retail Price Specification: Workgroup Software License Retail Price Specification for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:price "1574.90"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01#this> ;
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01#this> ;
-	schema:name "Software License Offer: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
+	schema:name "Software License Offer: Workgroup License for UDA 7.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-01#this> .
 
@@ -4466,13 +4478,13 @@
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-09-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/UDALTODBCRelease8LicenseWKS-anyos-postgres-personal-2019-09#this> ;
 	schema:image <http://uda.openlinksw.com/images/udast-basicworkstation-license.png> ;
-	skos:prefLabel "Software License: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
-	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	skos:prefLabel "Software License: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
+	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	schema:category "personal" ;
 	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
-	schema:description "Software License Offer: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System." ;
+	schema:description "Software License Offer: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System." ;
 	offers:offerNumber "UDALT-WKS-anyos-odbc-postgres-personal-2019-09"^^<http://www.w3.org/2001/XMLSchema#string> ;
-	schema:name "Software License Offer: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software License Offer: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	skos:related <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:hasBuyService <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKS-anyos-odbc-postgres-personal-2019-09%23this&type=buy&mode=u> ;
 	schema:potentialAction <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKS-anyos-odbc-postgres-personal-2019-09%23this> .
@@ -4490,7 +4502,7 @@
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-09-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDALiteSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software License Special Price Specification: Personal License Special Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software License Special Price Specification: Personal License Special Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-09-retail-price#this> ;
 	schema:price "99.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4501,31 +4513,35 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:workstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:description "Personal License for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x for installation on one (1) host with up to 16 logical processors, running a Workstation-class Operating System. Allows five (5) concurrent ODBC data access sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
+	schema:description "Personal License for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for installation on one (1) host with up to 16 logical processors, running a Workstation-class Operating System. Allows five (5) concurrent ODBC data access sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
 	schema:image <http://uda.openlinksw.com/images/udast-basicworkstation-license.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease8PostgreSQL#this> ;
-	schema:name "Software License: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software License: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-09#this> ;
-	skos:prefLabel "Software License: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
-	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	skos:prefLabel "Software License: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
+	schema:comment "Software License: Personal License (non-expiring, 16 logical processors, 5 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	license:hasLicenseCode "pgr7_lt" ;
 	license:hasLicenseFileName "pgr7_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:PostgreSQL9 .
+	oplsof:hasDatabaseEngine oplsof:PostgreSQL7 ,  
+                                 oplsof:PostgreSQL8 ,
+                                 oplsof:PostgreSQL9 ,
+                                 oplsof:PostgreSQL10 ,
+                                 oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKS-anyos-odbc-postgres-personal-2019-09-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software Software License Retail Price Specification: Personal Software License Retail Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System" ;
+	schema:name "Software Software License Retail Price Specification: Personal Software License Retail Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System" ;
 	schema:price "299.98"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-09#this> ;
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-09#this> ;
-	schema:name "Software License Offer: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
+	schema:name "Software License Offer: Personal License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKS-anyos-odbc-postgres-personal-2019-09#this> .
 
@@ -4536,13 +4552,13 @@
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/UDALTODBCRelease8LicenseWKSSVR-anyos-postgres-department-2019-09#this> ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
-	skos:prefLabel "Software License: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:category "department" ;
 	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
-	schema:description "Software License Offer: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:description "Software License Offer: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:offerNumber "UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09"^^<http://www.w3.org/2001/XMLSchema#string> ;
-	schema:name "Software License Offer: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Offer: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	skos:related <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:hasBuyService <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09%23this&type=buy&mode=u> ;
 	schema:potentialAction <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09%23this> .
@@ -4560,7 +4576,7 @@
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDALiteSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software License Special Price Specification: Department License Special Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Special Price Specification: Department License Special Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09-retail-price#this> ;
 	schema:price "1312.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4571,31 +4587,35 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:serverWorkstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:description "Department License for Lite Edition (Release 8.x) ODBC Driver for ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows twenty-five (25) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
+	schema:description "Department License for Lite Edition (Release 8.x) ODBC Driver for ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows twenty-five (25) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease8PostgreSQL#this> ;
-	schema:name "Software License: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09#this> ;
-	skos:prefLabel "Software License: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Department License (non-expiring, 16 logical processors, 25 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	license:hasLicenseCode "pgr7_lt" ;
 	license:hasLicenseFileName "pgr7_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:PostgreSQL9 .
+	oplsof:hasDatabaseEngine oplsof:PostgreSQL7 ,  
+                                 oplsof:PostgreSQL8 ,
+                                 oplsof:PostgreSQL9 ,
+                                 oplsof:PostgreSQL10 ,
+                                 oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software Software License Retail Price Specification: Department Software License Retail Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software Software License Retail Price Specification: Department Software License Retail Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:price "3937.24"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09#this> ;
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09#this> ;
-	schema:name "Software License Offer: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
+	schema:name "Software License Offer: Department License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-department-2019-09#this> .
 
@@ -4606,13 +4626,13 @@
 	schema:priceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09-special-price#this> ;
 	schema:itemOffered <http://data.openlinksw.com/oplweb/license/UDALTODBCRelease8LicenseWKSSVR-anyos-postgres-workgroup-2019-09#this> ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
-	skos:prefLabel "Software License: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:category "workgroup" ;
 	gr:businessFunction <http://schema.org/businessFunction#Sell> ;
-	schema:description "Software License Offer: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:description "Software License Offer: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:offerNumber "UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09"^^<http://www.w3.org/2001/XMLSchema#string> ;
-	schema:name "Software License Offer: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Offer: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	skos:related <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:hasBuyService <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09%23this&type=buy&mode=u> ;
 	schema:potentialAction <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09%23this> .
@@ -4630,7 +4650,7 @@
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09-special-price#this> a schema:UnitPriceSpecification , offers:SpecialUnitPriceSpecification , offers:UDALiteSpecialUnitPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software License Special Price Specification: Workgroup License Special Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License Special Price Specification: Workgroup License Special Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09-retail-price#this> ;
 	schema:price "524.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
@@ -4641,31 +4661,35 @@
 	license:maxNetworkInstance "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	oplsof:hasOperatingSystemType oplsof:serverWorkstationOS ;
 	oplsof:hasOperatingSystemFamily oplsof:OSFamilyAny ;
-	schema:description "Workgroup License for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows ten (10) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
+	schema:description "Workgroup License for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for installation on one (1) host with up to 16 logical processors, running a Workstation- or Server-class Operating System. Allows ten (10) concurrent ODBC sessions from licensed host, and is transferable across hosts running supported operating systems, without expiration." ;
 	schema:image <http://uda.openlinksw.com/images/udast-dualappdbserver-license.png> ;
 	license:productLicenseOf <http://data.openlinksw.com/oplweb/product_release/UDASingleTierLiteEditionODBCRelease8PostgreSQL#this> ;
-	schema:name "Software License: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software License: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:model <http://data.openlinksw.com/oplweb/product/odbc-postgres-st#this> ;
 	license:serialNumberBroadcast "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	license:partOf <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09#this> ;
-	skos:prefLabel "Software License: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
-	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	skos:prefLabel "Software License: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:comment "Software License: Workgroup License (non-expiring, 16 logical processors, 10 sessions) for Lite Edition (Release 8.x) ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	license:hasLicenseCode "pgr7_lt" ;
 	license:hasLicenseFileName "pgr7_lt.lic" ;
 	oplsof:hasDatabaseFamily oplsof:PostgreSQL ;
 	oplsof:hasDataAccessProtocolScope oplsof:DataAccessODBC ;
-	oplsof:hasDatabaseEngine oplsof:PostgreSQL9 .
+	oplsof:hasDatabaseEngine oplsof:PostgreSQL7 ,  
+                                 oplsof:PostgreSQL8 ,
+                                 oplsof:PostgreSQL9 ,
+                                 oplsof:PostgreSQL10 ,
+                                 oplsof:PostgreSQL11 .
 
 <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09-retail-price#this> a schema:UnitPriceSpecificiation , offers:RetailPriceSpecification ;
 	schema:validFrom "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	schema:validThrough "2019-09-30T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	schema:name "Software Software License Retail Price Specification: Workgroup Software License Retail Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System" ;
+	schema:name "Software Software License Retail Price Specification: Workgroup Software License Retail Price Specification for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System" ;
 	schema:price "1574.90"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	schema:priceCurrency "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09#this> ;
 	schema:about <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09#this> ;
-	schema:name "Software License Offer: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
+	schema:name "Software License Offer: Workgroup License for UDA 8.x Lite Edition ODBC Driver for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x for deployment on any supported Workstation- or Server-class Operating System"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this> schema:offers <http://data.openlinksw.com/oplweb/offer/Offer-UDALT-WKSSVR-anyos-odbc-postgres-workgroup-2019-09#this> .
 


### PR DESCRIPTION
Updated the lite license descriptions to include Postgres 10 and 11
Postgres 10 and 11 needed adding to the oplsof:hasDatabaseEngines relation of the Postgres licenses.
The type <http://www.openlinksw.com/ontology/licenses#DatabaseAgentLicense> was missing from the agent licenses
Some database engine objects were strings not URIs
Added the multitier Postgres offers and licenses 