### PR TITLE
Update UDAEnterpriseOffers-Licenses-Prices.ttl

### DIFF
--- a/UDAEnterpriseOffers-Licenses-Prices.ttl
+++ b/UDAEnterpriseOffers-Licenses-Prices.ttl
@@ -22,10 +22,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-jdbc-department"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en .
 
@@ -71,11 +71,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7JDBCBridge#this> ;
     schema:name                        "Department License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -85,7 +85,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-department#this> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "jdbc" ;
     license:hasLicenseFileName         "jdbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
@@ -116,7 +116,7 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
@@ -133,8 +133,8 @@
     schema:name                        "Department License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
-    schema:description                 "Department License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Department License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:hasLicenseCode             "oplrqb" ;
     license:hasLicenseFileName         "oplrqb.lic" ;
@@ -157,10 +157,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
@@ -200,11 +200,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7JDBCBridge#this> ;
     schema:name                        "Workgroup License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -214,7 +214,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup#this> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "jdbc" ;
     license:hasLicenseFileName         "jdbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
@@ -241,8 +241,8 @@
     schema:name                        "Workgroup License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
-    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en .
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this>
     schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup#this> .
@@ -261,10 +261,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-odbc-department"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en .
 
@@ -310,11 +310,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7ODBCBridge#this> ;
     schema:name                        "Department License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -324,7 +324,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-department#this> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "odbc" ;
     license:hasLicenseFileName         "odbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
@@ -367,10 +367,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-odbc-workgroup"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
@@ -410,11 +410,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7ODBCBridge#this> ;
     schema:name                        "Workgroup License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -424,7 +424,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-workgroup#this> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "odbc" ;
     license:hasLicenseFileName         "odbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
@@ -466,10 +466,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en .
 
@@ -515,11 +515,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Oracle#this> ;
     schema:name                        "Department License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -529,7 +529,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-department#this> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "oracle12" ;
     license:hasLicenseFileName         "oracle12.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Oracle ;
@@ -574,10 +574,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-oracle12-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
@@ -617,11 +617,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Oracle#this> ;
     schema:name                        "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -631,7 +631,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-workgroup#this> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "oracle12" ;
     license:hasLicenseFileName         "oracle12.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Oracle ;
@@ -675,10 +675,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en .
 
@@ -724,11 +724,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7SQLServer#this> ;
     schema:name                        "Department License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -738,7 +738,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department#this> ;
     skos:prefLabel                     "Department License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "sqlserver" ;
     license:hasLicenseFileName         "sqlserver.lic" ;
     oplsof:hasDatabaseFamily           oplsof:SQLServer ;
@@ -781,10 +781,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 7.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-sqlserver-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
@@ -824,11 +824,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7SQLServer#this> ;
     schema:name                        "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
@@ -838,7 +838,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-workgroup#this> ;
     skos:prefLabel                     "Workgroup License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "sqlserver" ;
     license:hasLicenseFileName         "sqlserver.lic" ;
     oplsof:hasDatabaseFamily           oplsof:SQLServer ;
@@ -880,10 +880,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
@@ -891,8 +891,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal%23this> .
 
 <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal%23this&type=buy&mode=u%23this&type=buy&mode=v>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.97"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal#this>
     schema:mainEntityOfPage            <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal%23this&type=buy&mode=u%23this&type=buy&mode=v> .
@@ -914,7 +914,7 @@
 
     schema:name                        "Personal License Special Price Specification to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-retail-price#this> ;
-    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense7-personal-2022-01#this>
@@ -923,11 +923,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7JDBCBridge#this> ;
     schema:name                        "Personal License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
@@ -937,7 +937,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal#this> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "jdbc" ;
     license:hasLicenseFileName         "jdbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
@@ -951,7 +951,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 7.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -966,7 +966,7 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
@@ -983,8 +983,8 @@
     schema:name                        "Personal License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
-    schema:description                 "Personal License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:hasLicenseCode             "oplrqb" ;
     license:hasLicenseFileName         "oplrqb.lic" ;
@@ -1007,10 +1007,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
@@ -1018,8 +1018,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal%23this> .
 
 <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal%23this&type=buy&mode=u%23this&type=buy&mode=v>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.97"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal#this>
     schema:mainEntityOfPage            <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal%23this&type=buy&mode=u%23this&type=buy&mode=v> .
@@ -1050,11 +1050,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7ODBCBridge#this> ;
     schema:name                        "Personal License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
@@ -1064,7 +1064,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal#this> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "odbc" ;
     license:hasLicenseFileName         "odbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
@@ -1078,7 +1078,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 7.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -1093,7 +1093,7 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
@@ -1105,8 +1105,8 @@
     schema:name                        "Personal License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
-    schema:description                 "Personal License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 7.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:hasLicenseCode             "oplrqb" ;
     license:hasLicenseFileName         "oplrqb.lic" ;
@@ -1123,16 +1123,16 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceSpecification          <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-oracle12-personal-special-price#this> ;
     schema:itemOffered                 <http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSDBAgentLicense7-personal-2022-01#this> ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
@@ -1140,8 +1140,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-oracle12-personal%23this> .
 
 <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-oracle12-personal%23this&type=buy&mode=u%23this&type=buy&mode=v>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal#this>
     schema:mainEntityOfPage            <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-oracle12-personal%23this&type=buy&mode=u%23this&type=buy&mode=v> .
@@ -1163,7 +1163,7 @@
 
     schema:name                        "Personal License Special Price Specification to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-oracle12-personal-retail-price#this> ;
-    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/license/AnyDataAccessoracle12AnyOSWKSDBAgentLicense7-personal-2022-01#this>
@@ -1172,11 +1172,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Oracle#this> ;
     schema:name                        "Personal License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
@@ -1186,7 +1186,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal#this> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "oracle12" ;
     license:hasLicenseFileName         "oracle12.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Oracle ;
@@ -1202,7 +1202,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 7.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -1225,16 +1225,16 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceSpecification          <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-special-price#this> ;
     schema:itemOffered                 <http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense7-personal-2022-01#this> ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 7.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
@@ -1242,8 +1242,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this> .
 
 <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this&type=buy&mode=u%23this&type=buy&mode=v>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal#this>
     schema:mainEntityOfPage            <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this&type=buy&mode=u%23this&type=buy&mode=v> .
@@ -1265,7 +1265,7 @@
 
     schema:name                        "Personal License Special Price Specification to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-retail-price#this> ;
-    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense7-personal-2022-01#this>
@@ -1274,11 +1274,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease7Sybase#this> ;
     schema:name                        "Personal License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
@@ -1288,7 +1288,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal#this> ;
     skos:prefLabel                     "Personal License to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "sqlserver" ;
     license:hasLicenseFileName         "sqlserver.lic" ;
     oplsof:hasDatabaseFamily           oplsof:SQLServer ;
@@ -1302,7 +1302,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 7.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -1335,10 +1335,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-jdbc-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
@@ -1378,11 +1378,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8JDBCBridge#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8JDBCBridge#this> ,
@@ -1394,7 +1394,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "jdbc" ;
     license:hasLicenseFileName         "jdbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
@@ -1425,7 +1425,7 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
@@ -1442,8 +1442,8 @@
     schema:name                        "Department License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:hasLicenseCode             "oplrqb" ;
     license:hasLicenseFileName         "oplrqb.lic" ;
@@ -1466,10 +1466,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
@@ -1509,11 +1509,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8JDBCBridge#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8JDBCBridge#this> ,
@@ -1525,7 +1525,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "jdbc" ;
     license:hasLicenseFileName         "jdbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
@@ -1552,8 +1552,8 @@
     schema:name                        "Workgroup License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en .
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en .
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this>
     schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-jdbc-workgroup-2022-01#this> .
@@ -1572,10 +1572,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-odbc-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
@@ -1615,11 +1615,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8ODBCBridge#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8ODBCBridge#this> ,
@@ -1631,7 +1631,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "odbc" ;
     license:hasLicenseFileName         "odbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
@@ -1674,10 +1674,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-odbc-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
@@ -1717,11 +1717,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8ODBCBridge#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8ODBCBridge#this> ,
@@ -1733,7 +1733,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-odbc-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "odbc" ;
     license:hasLicenseFileName         "odbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
@@ -1775,10 +1775,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
@@ -1818,11 +1818,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Oracle#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Oracle#this> ,
@@ -1834,7 +1834,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "oracle12" ;
     license:hasLicenseFileName         "oracle12.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Oracle ;
@@ -1879,10 +1879,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-oracle12-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
@@ -1922,11 +1922,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Oracle#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Oracle#this> ,
@@ -1938,7 +1938,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-oracle12-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "oracle12" ;
     license:hasLicenseFileName         "oracle12.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Oracle ;
@@ -1982,10 +1982,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
@@ -2025,11 +2025,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8SQLServer#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8SQLServer#this> ,
@@ -2041,7 +2041,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "sqlserver" ;
     license:hasLicenseFileName         "sqlserver.lic" ;
     oplsof:hasDatabaseFamily           oplsof:SQLServer ;
@@ -2084,10 +2084,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) for UDA 8.x Enterprise Edition Data Access (ODBC, JDBC, and ADO.NET Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-sqlserver-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
@@ -2127,11 +2127,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8SQLServer#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8SQLServer#this> ,
@@ -2143,7 +2143,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKSSVR-anyos-anydataccess-sqlserver-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "sqlserver" ;
     license:hasLicenseFileName         "sqlserver.lic" ;
     oplsof:hasDatabaseFamily           oplsof:SQLServer ;
@@ -2185,10 +2185,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
@@ -2196,8 +2196,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01%23this&type=buy&mode=u> .
@@ -2228,11 +2228,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8JDBCBridge#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8JDBCBridge#this> ,
@@ -2244,7 +2244,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "jdbc" ;
     license:hasLicenseFileName         "jdbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
@@ -2258,7 +2258,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -2273,7 +2273,7 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
@@ -2290,8 +2290,8 @@
     schema:name                        "Personal License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:hasLicenseCode             "oplrqb" ;
     license:hasLicenseFileName         "oplrqb.lic" ;
@@ -2314,10 +2314,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
@@ -2325,8 +2325,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01%23this&type=buy&mode=u> .
@@ -2357,11 +2357,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8ODBCBridge#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8ODBCBridge#this> ,
@@ -2373,7 +2373,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "odbc" ;
     license:hasLicenseFileName         "odbc.lic" ;
     oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
@@ -2387,7 +2387,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -2402,7 +2402,7 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
@@ -2414,8 +2414,8 @@
     schema:name                        "Personal License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:hasLicenseCode             "oplrqb" ;
     license:hasLicenseFileName         "oplrqb.lic" ;
@@ -2438,10 +2438,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Oracle 12.x, Oracle 19c and Oracle 21c, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-oracle-mt#this> ;
@@ -2449,8 +2449,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01%23this&type=buy&mode=u> .
@@ -2481,11 +2481,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Oracle#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Oracle#this> ,
@@ -2497,7 +2497,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-oracle12-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "oracle12" ;
     license:hasLicenseFileName         "oracle12.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Oracle ;
@@ -2513,7 +2513,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for Oracle 12.x, Oracle 19c and Oracle 21c, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -2542,10 +2542,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
@@ -2553,8 +2553,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01%23this&type=buy&mode=u> .
@@ -2585,11 +2585,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Sybase#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Sybase#this> ,
@@ -2601,7 +2601,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "sqlserver" ;
     license:hasLicenseFileName         "sqlserver.lic" ;
     oplsof:hasDatabaseFamily           oplsof:SQLServer ;
@@ -2615,7 +2615,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -2644,10 +2644,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-postgres-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-postgres-mt#this> ;
@@ -2655,8 +2655,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2022-01%23this&type=buy&mode=u> .
@@ -2687,11 +2687,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8PostgreSQL#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8PostgreSQL#this> ,
@@ -2703,7 +2703,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "postgres" ;
     license:hasLicenseFileName         "postgres.lic" ;
     oplsof:hasDatabaseFamily           oplsof:PostgreSQL ;
@@ -2723,7 +2723,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -2752,10 +2752,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-postgres-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-postgres-mt#this> ;
@@ -2795,11 +2795,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8PostgreSQL#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8PostgreSQL#this> ,
@@ -2811,7 +2811,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "postgres" ;
     license:hasLicenseFileName         "postgres.lic" ;
     oplsof:hasDatabaseFamily           oplsof:PostgreSQL ;
@@ -2860,10 +2860,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-postgres-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-postgres-mt#this> ;
@@ -2903,11 +2903,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8PostgreSQL#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8PostgreSQL#this> ,
@@ -2919,7 +2919,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-postgres-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for PostgreSQL 7.x, 8.x, 9.x, 10.x, 11.x and 12.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "postgres" ;
     license:hasLicenseFileName         "postgres.lic" ;
     oplsof:hasDatabaseFamily           oplsof:PostgreSQL ;
@@ -2970,10 +2970,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-mysql5-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-mysql-mt#this> ;
@@ -2981,8 +2981,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-mysql5-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-mysql5-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-mysql5-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-mysql5-personal-2022-01%23this&type=buy&mode=u> .
@@ -3012,11 +3012,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8MySQL#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8MySQL#this> ,
@@ -3028,7 +3028,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-mysql5-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "mysql5" ;
     license:hasLicenseFileName         "mysql5.lic" ;
     oplsof:hasDatabaseFamily           oplsof:MySQL ;
@@ -3042,7 +3042,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -3071,10 +3071,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-mysql5-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-mysql-mt#this> ;
@@ -3114,11 +3114,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8MySQL#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8MySQL#this> ,
@@ -3130,7 +3130,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-mysql5-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "mysql5" ;
     license:hasLicenseFileName         "mysql5.lic" ;
     oplsof:hasDatabaseFamily           oplsof:MySQL ;
@@ -3173,10 +3173,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-mysql5-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for MySQL 5.x, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-mysql-mt#this> ;
@@ -3216,11 +3216,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8MySQL#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8MySQL#this> ,
@@ -3232,7 +3232,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-mysql5-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for MySQL 5.x, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "mysql5" ;
     license:hasLicenseFileName         "mysql5.lic" ;
     oplsof:hasDatabaseFamily           oplsof:MySQL ;
@@ -3277,10 +3277,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     schema:category                    "personal"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-inf11-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Personal License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-informix-mt#this> ;
@@ -3288,8 +3288,8 @@
     schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-inf11-personal-2022-01%23this> .
 
 <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-inf11-personal-2022-01%23this&type=buy&mode=u>
-    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> ;
-    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1499.97"^^<http://www.w3.org/2001/XMLSchema#string> .
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 1249.99"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-inf11-personal-2022-01#this>
     schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-inf11-personal-2022-01%23this&type=buy&mode=u> .
@@ -3319,11 +3319,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:workstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for Informix 11, Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:description                 "Personal License to UDA 8.x Enterprise Edition Database Agent for Informix 11, Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Informix#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Informix#this> ,
@@ -3335,7 +3335,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-inf11-personal-2022-01#this> ;
     skos:prefLabel                     "Personal License to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
     skos:altLabel                      "Personal License"@en ;
-    schema:comment                     "Personal License (1 year duration, 5 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
     license:hasLicenseCode             "informix11" ;
     license:hasLicenseFileName         "informix11.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Informix ;
@@ -3349,7 +3349,7 @@
     schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 
     schema:name                        "Personal Software License Retail Price Specification to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
-    schema:price                       "1499.97"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
     schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
 
 <http://uda.openlinksw.com/offers/>
@@ -3378,10 +3378,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "workgroup"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Software License Offer: Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-inf11-workgroup-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Workgroup License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-informix-mt#this> ;
@@ -3421,11 +3421,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "10"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Informix 11, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
+    schema:description                 "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Informix 11, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 10 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 10 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Informix#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Informix#this> ,
@@ -3437,7 +3437,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-inf11-workgroup-2022-01#this> ;
     skos:prefLabel                     "Workgroup License to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Workgroup License"@en ;
-    schema:comment                     "Workgroup License (10 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Workgroup License (10 database sessions) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "informix11" ;
     license:hasLicenseFileName         "informix11.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Informix ;
@@ -3480,10 +3480,10 @@
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     schema:category                    "department"@en ;
     gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
-    schema:description                 "Software License Offer: Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:description                 "Software License Offer: Department License (25 database sessions) to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     offers:offerNumber                 "UDAMT-WKSSVR-anyos-anydataccess-inf11-department-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
     schema:name                        "Software License Offer: Department License to UDA 8.x Enterprise Edition (All Data Access Mechanisms) for Informix 11, for deployment on any supported Workstation- or Server-class Operating System."@en ;
     skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-informix-mt#this> ;
@@ -3523,11 +3523,11 @@
                                        license:ExpiringLicense ,
                                        license:DatabaseAgentLicense, license:UDAMTLicense ;
     license:hasSessions                "25"^^<http://www.w3.org/2001/XMLSchema#int> ;
-    license:hasMaximumProcessorCores   "16"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
     license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
     oplsof:hasOperatingSystemType      oplsof:serverWorkstationOS ;
     oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
-    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for Informix 11, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 16 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
+    schema:description                 "Department License to UDA 8.x Enterprise Edition Database Agent for Informix 11, Permits installation of Database Agent on one (1) server host running any Workstation- or Server-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 25 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 25 concurrent client hosts."@en ;
     schema:image                       <https://uda.openlinksw.com/images/udamt-dualappdbserver-license.png> ;
     license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease8Informix#this> ,
                                        <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease8Informix#this> ,
@@ -3539,7 +3539,7 @@
     license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-inf11-department-2022-01#this> ;
     skos:prefLabel                     "Department License to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms, for deployment on any supported Workstation- or Server-class Operating System"@en ;
     skos:altLabel                      "Department License"@en ;
-    schema:comment                     "Department License (25 database sessions, 16 logical processors) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
+    schema:comment                     "Department License (25 database sessions) to UDA 8.x Enterprise Edition Database Agent for Informix 11, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation- or Server-class Operating System"@en ;
     license:hasLicenseCode             "informix11" ;
     license:hasLicenseFileName         "informix11.lic" ;
     oplsof:hasDatabaseFamily           oplsof:Informix ;
@@ -3567,3 +3567,408 @@
 
 <http://www.openlinksw.com/dataspace/organization/openlink#this>
     schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-inf11-department-2022-01#this> .
+
+# Release 9.x
+
+# Release 9.x Enterprise Edition Offers
+# Note, these are appeneded to the main UDAEntrepriseOffers-Licenses-Prices.ttl
+
+@prefix schema: <http://schema.org/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix offers: <http://www.openlinksw.com/ontology/offers#> .
+@prefix oplpro: <http://www.openlinksw.com/ontology/products#> .
+@prefix license: <http://www.openlinksw.com/ontology/licenses#> .
+@prefix gr: <http://purl.org/goodrelations/v1#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix oplsof: <http://www.openlinksw.com/ontology/software#> .
+
+## JDBC Bridge
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this>
+    a                                  schema:Offer ,
+                                       offers:UDAEnterpriseOffer ,
+                                       offers:UDAEnterpriseSpecialOffer ;
+    schema:url                         <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceSpecification          <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10-special-price#this> ;
+    schema:itemOffered                 <http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense8-personal-2024-10#this> ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:category                    "personal"@en ;
+    gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
+    offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "Software License Offer: Personal License to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."@en ;
+    skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
+    license:hasBuyService              <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this&type=buy&mode=u> ;
+    schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this> .
+
+<http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this&type=buy&mode=u>
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 499.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 499.99"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this>
+    schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this&type=buy&mode=u> .
+
+<https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this>
+    schema:description                 "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this>
+    schema:mainEntityOfPage            <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10%23this> ;
+    schema:itemOffered                 <http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2024-10#this> .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10-special-price#this>
+    a                                  schema:UnitPriceSpecification ,
+                                       offers:SpecialUnitPriceSpecification ,
+                                       offers:UDAEnterpriseSpecialUnitPriceSpecification ;
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:name                        "Personal License Special Price Specification to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10-retail-price#this> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessjdbcAnyOSWKSDBAgentLicense8-personal-2024-10#this>
+    a                                  schema:Product ,
+                                       license:ProductLicense ,
+                                       license:ExpiringLicense ,
+                                       license:DatabaseAgentLicense, license:UDAMTLicense ;
+    license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    oplsof:hasOperatingSystemType      oplsof:workstationOS ;
+    oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
+    schema:description                 "Personal License to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9JDBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease9JDBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionJDBCRelease9JDBCBridge#this> ;
+    schema:name                        "Personal License to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
+    license:serialNumberBroadcast      "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasDuration                 <http://data.openlinksw.com/oplweb/license/License-Duration#annual> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this> ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    license:hasLicenseCode             "jdbc" ;
+    license:hasLicenseFileName         "jdbc.lic" ;
+    oplsof:hasDatabaseFamily           oplsof:JDBCBridge ;
+    oplsof:hasDataAccessProtocolScope  oplsof:DataAccessProtocolAny ;
+    oplsof:hasDatabaseEngine           oplsof:jdbc .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10-retail-price#this>
+    a                                  schema:UnitPriceSpecification ,
+                                       offers:RetailPriceSpecification ;
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:name                        "Personal Software License Retail Price Specification to UDA 9.x Enterprise Edition Database Agent for JDBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://uda.openlinksw.com/offers/>
+    schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this> ;
+    schema:about                       <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this> ;
+    schema:name                        "Software License Offer: Personal License to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for JDBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2024-10#this>
+    a                                  schema:Product ,
+                                       license:ProductLicense ,
+                                       license:RequestBrokerLicense ,
+                                       license:ExpiringLicense ,
+                                       license:DatabaseAgentLicense, license:UDAMTLicense ;
+    license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    oplsof:hasOperatingSystemType      oplsof:workstationOS ;
+    oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
+    license:serialNumberBroadcast      "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasDuration                 <http://data.openlinksw.com/oplweb/license/License-Duration#annual> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this> ;
+    license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9JDBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9ODBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9SQLServer#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9Oracle#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9Sybase#this> ;
+    license:hasMaximumUsers            "unlimited"@en ;
+    schema:name                        "Personal License to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 9.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    license:hasLicenseCode             "oplrqb" ;
+    license:hasLicenseFileName         "oplrqb.lic" ;
+    oplsof:hasProtocolScope            oplsof:DataAccessProtocolAny .
+
+<http://www.openlinksw.com/dataspace/organization/openlink#this>
+    schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-jdbc-personal-2024-10#this> .
+
+## ODBC Bridge 
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this>
+    a                                  schema:Offer ,
+                                       offers:UDAEnterpriseOffer ,
+                                       offers:UDAEnterpriseSpecialOffer ;
+    schema:url                         <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:price                       "449.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceSpecification          <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10-special-price#this> ;
+    schema:itemOffered                 <http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSDBAgentLicense8-personal-2024-10#this> ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:category                    "personal"@en ;
+    gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System"@en ;
+    offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "Software License Offer: Personal License to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System."@en ;
+    skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
+    license:hasBuyService              <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this&type=buy&mode=u> ;
+    schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this> .
+
+<http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this&type=buy&mode=u>
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 499.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 499.99"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this>
+    schema:mainEntityOfPage            <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this&type=buy&mode=u> .
+
+<https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this>
+    schema:description                 "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this>
+    schema:mainEntityOfPage            <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10%23this> ;
+    schema:itemOffered                 <http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2024-10#this> .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10-special-price#this>
+    a                                  schema:UnitPriceSpecification ,
+                                       offers:SpecialUnitPriceSpecification ,
+                                       offers:UDAEnterpriseSpecialUnitPriceSpecification ;
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:name                        "Personal License Special Price Specification to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10-retail-price#this> ;
+    schema:price                       "449.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/license/AnyDataAccessodbcAnyOSWKSDBAgentLicense8-personal-2024-10#this>
+    a                                  schema:Product ,
+                                       license:ProductLicense ,
+                                       license:ExpiringLicense ,
+                                       license:DatabaseAgentLicense, license:UDAMTLicense ;
+    license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    oplsof:hasOperatingSystemType      oplsof:workstationOS ;
+    oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
+    schema:description                 "Personal License to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9ODBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionODBCRelease9ODBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionJDBCRelease9ODBCBridge#this> ;
+    schema:name                        "Personal License to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
+    license:serialNumberBroadcast      "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasDuration                 <http://data.openlinksw.com/oplweb/license/License-Duration#annual> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this> ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    license:hasLicenseCode             "odbc" ;
+    license:hasLicenseFileName         "odbc.lic" ;
+    oplsof:hasDatabaseFamily           oplsof:ODBCBridge ;
+    oplsof:hasDataAccessProtocolScope  oplsof:DataAccessProtocolAny ;
+    oplsof:hasDatabaseEngine           oplsof:odbc .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10-retail-price#this>
+    a                                  schema:UnitPriceSpecification ,
+                                       offers:RetailPriceSpecification ;
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:name                        "Personal Software License Retail Price Specification to UDA 9.x Enterprise Edition Database Agent for ODBC Data Sources, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://uda.openlinksw.com/offers/>
+    schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this> ;
+    schema:about                       <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this> ;
+    schema:name                        "Software License Offer: Personal License to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for ODBC Data Sources, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense8-personal-2024-10#this>
+    a                                  schema:Product ,
+                                       license:ProductLicense ,
+                                       license:RequestBrokerLicense ,
+                                       license:ExpiringLicense ,
+                                       license:DatabaseAgentLicense, license:UDAMTLicense ;
+    license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    oplsof:hasOperatingSystemType      oplsof:workstationOS ;
+    oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-odbc-mt#this> ;
+    license:serialNumberBroadcast      "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasDuration                 <http://data.openlinksw.com/oplweb/license/License-Duration#annual> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this> ;
+    license:hasMaximumUsers            "unlimited"@en ;
+    schema:name                        "Personal License to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 9.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    license:hasLicenseCode             "oplrqb" ;
+    license:hasLicenseFileName         "oplrqb.lic" ;
+    oplsof:hasProtocolScope            oplsof:DataAccessProtocolAny .
+
+<http://www.openlinksw.com/dataspace/organization/openlink#this>
+    schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-odbc-personal-2024-10#this> .
+
+## SQL Server
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this>
+    a                                  schema:Offer ,
+                                       offers:UDAEnterpriseOffer ,
+                                       offers:UDAEnterpriseSpecialOffer ;
+    schema:url                         <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceSpecification          <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-special-price#this> ;
+    schema:itemOffered                 <http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense9-personal-2024-10#this> ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:category                    "personal"@en ;
+    gr:businessFunction                <http://schema.org/businessFunction#Sell> ;
+    schema:description                 "Software License Offer: Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System"@en ;
+    offers:offerNumber                 "UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2022-01"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "Software License Offer: Personal License to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System."@en ;
+    skos:related                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
+    license:hasBuyService              <http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this&type=buy&mode=u> ;
+    schema:potentialAction             <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this> .
+
+<http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this&type=buy&mode=u%23this&type=buy&mode=v>
+    schema:description                 "HTML Document Generated via BuyAction for REST-ful listing of Offer: 499.99"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "HTML Document Generated via BuyAction for listing of Offer: 499.99"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this>
+    schema:mainEntityOfPage            <http://virtuoso.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-http://uda.openlinksw.com/offers/order?uri=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this&type=buy&mode=u%23this&type=buy&mode=v> .
+
+<https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this>
+    schema:description                 "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this"^^<http://www.w3.org/2001/XMLSchema#string> ;
+    schema:name                        "https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal%23this"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this>
+    schema:mainEntityOfPage            <https://shop.openlinksw.com/cart.vsp?command=add&item=http%3A%2F%2Fdata.openlinksw.com%2Foplweb%2Foffer%2FOffer-UDAMT-WKS-anyos-anydataccess-sqlserver-persona0%23this> ;
+    schema:itemOffered                 <http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense9-personal-2024-01#this>,
+                                       <http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense9-personal-2022-01#this> .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-special-price#this>
+    a                                  schema:UnitPriceSpecification ,
+                                       offers:SpecialUnitPriceSpecification ,
+                                       offers:UDAEnterpriseSpecialUnitPriceSpecification ;
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:name                        "Personal License Special Price Specification to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    offers:hasRetailPriceSpecification <http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-retail-price#this> ;
+    schema:price                       "499.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/license/AnyDataAccesssqlserverAnyOSWKSDBAgentLicense9-personal-2024-10#this>
+    a                                  schema:Product ,
+                                       license:ProductLicense ,
+                                       license:ExpiringLicense ,
+                                       license:DatabaseAgentLicense, license:UDAMTLicense ;
+    license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    oplsof:hasOperatingSystemType      oplsof:workstationOS ;
+    oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
+    schema:description                 "Personal License to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase. Permits installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9SQLServer#this> ;
+    schema:name                        "Personal License to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
+    license:serialNumberBroadcast      "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasDuration                 <http://data.openlinksw.com/oplweb/license/License-Duration#annual> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this> ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    license:hasLicenseCode             "sqlserver" ;
+    license:hasLicenseFileName         "sqlserver.lic" ;
+    oplsof:hasDatabaseFamily           oplsof:SQLServer ;
+    oplsof:hasDataAccessProtocolScope  oplsof:DataAccessProtocolAny ;
+    oplsof:hasDatabaseEngine           oplsof:SQLServer2014 .
+
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense9-personal-2024-01#this>
+    a                                  schema:Product ,
+                                       license:ProductLicense ,
+                                       license:RequestBrokerLicense ,
+                                       license:ExpiringLicense ,
+                                       license:DatabaseAgentLicense, license:UDAMTLicense ;
+    license:hasSessions                "5"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasMaximumProcessorCores   "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:maxNetworkInstance         "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    oplsof:hasOperatingSystemType      oplsof:workstationOS ;
+    oplsof:hasOperatingSystemFamily    oplsof:OSFamilyAny ;
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-jdbc-bridge-mt#this> ;
+    license:serialNumberBroadcast      "1"^^<http://www.w3.org/2001/XMLSchema#int> ;
+    license:hasDuration                 <http://data.openlinksw.com/oplweb/license/License-Duration#annual> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this> ;
+    license:productLicenseOf           <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9JDBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9ODBCBridge#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9SQLServer#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9Oracle#this> ,
+                                       <http://data.openlinksw.com/oplweb/product_release/UDAMultiTierEnterpriseEditionAnyDataAccessRelease9Sybase#this> ;
+    license:hasMaximumUsers            "unlimited"@en ;
+    schema:name                        "Personal License to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:prefLabel                     "Personal License to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    skos:altLabel                      "Personal License"@en ;
+    schema:comment                     "Personal License (1 year duration, 5 database sessions) to UDA 9.x Enterprise Edition Request Broker, enabling All Data Access Mechanisms (ODBC, JDBC, and ADO.NET), for deployment on any supported Workstation-class Operating System"@en ;
+    schema:description                 "Personal License to UDA 9.x Enterprise Edition Request Broker. Supports installation of Database Agent on one (1) server host running any Workstation-class Operating System with up to 0 logical processors without additional charges, and is transferable across hosts running supported operating systems, with one year duration. Enables a pool of 5 concurrent generic client (ODBC, JDBC, and/or ADO.NET) sessions to be shared by up to 5 concurrent client hosts."@en ;
+    schema:image                       <https://uda.openlinksw.com/images/udamt-basicworkstation-license.png> ;
+    license:hasLicenseCode             "oplrqb" ;
+    license:hasLicenseFileName         "oplrqb.lic" ;
+    oplsof:hasProtocolScope            oplsof:DataAccessProtocolAny .
+
+<http://data.openlinksw.com/oplweb/offer-unitprice/UnitPriceSpecification-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-retail-price#this>
+    a                                  schema:UnitPriceSpecification ,
+                                       offers:RetailPriceSpecification ;
+    schema:validFrom                   "2019-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+    schema:validThrough                "2024-10-31T23:59:59Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
+
+    schema:name                        "Personal Software License Retail Price Specification to UDA 9.x Enterprise Edition Database Agent for Microsoft SQL Server & Sybase, enabling All Data Access Mechanisms, for deployment on any supported Workstation-class Operating System"@en ;
+    schema:price                       "1249.99"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
+    schema:priceCurrency               "USD"^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://uda.openlinksw.com/offers/>
+    schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this> ;
+    schema:about                       <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this> ;
+    schema:name                        "Software License Offer: Personal License to UDA 9.x Enterprise Edition (All Data Access Mechanisms) for Microsoft SQL Server & Sybase, for deployment on any supported Workstation-class Operating System."^^<http://www.w3.org/2001/XMLSchema#string> .
+
+<http://data.openlinksw.com/oplweb/licenseAnyDataAccessAnyOSWKSRequestBrokerLicense9-personal-2024-01#this>
+    schema:model                       <http://data.openlinksw.com/oplweb/product/odbc-sqlserver-mt#this> ;
+    license:partOf                     <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this> .
+
+<http://www.openlinksw.com/dataspace/organization/openlink#this>
+    schema:offers                      <http://data.openlinksw.com/oplweb/offer/Offer-UDAMT-WKS-anyos-anydataccess-sqlserver-personal-2024-10#this> .


### PR DESCRIPTION
Added missing 9.x Request Broker License for 9.x Offers. Also fixed an errant offer price i.e., set to 499.99 from 1249.95.